### PR TITLE
Removed necessity for :has() selector in css

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
 
       <!--   Group 1 -->
       <div class="media-group" id="group-1">
+        <div class="previous"></div>
         <div class="media-element">
           <img
             src="https://images.unsplash.com/photo-1641353989082-9b15fa661805?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxNDU4OXwwfDF8cmFuZG9tfHx8fHx8fHx8MTY0MzM5ODcyOA&ixlib=rb-1.2.1&q=80&w=400"
@@ -167,6 +168,7 @@
             src="https://images.unsplash.com/photo-1643148636637-58b3eb95cdad?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxNDU4OXwwfDF8cmFuZG9tfHx8fHx8fHx8MTY0MzM5ODg0OA&ixlib=rb-1.2.1&q=80&w=400"
             alt="">
         </div>
+        <div class="next"></div>
       </div>
 
       <div class="navigation-indicators">

--- a/style.css
+++ b/style.css
@@ -112,15 +112,11 @@ svg {
   bottom: 0;
 }
 
-.media-group:first-child :where(.next, .previous) {
-  display: flex;
-}
-
-.media-scroller:hover :where(.next, .previous) {
+.media-group:hover :where(.next, .previous) {
   opacity: 1;
 }
 
-:where(.next, .previous):hover {
+:where(.next, .previous):not(div):hover {
   background: rgb(0 0 0 / 0.3);
 }
 
@@ -136,10 +132,8 @@ svg {
   display: flex;
 }
 
-.media-scroller:has(:target:not(:first-child))
-  .media-group:first-of-type
-  .next {
-  display: none;
+.media-scroller:hover .media-group:nth-child(1):hover .next{
+  display: flex
 }
 
 /* navigation indicators */
@@ -161,14 +155,7 @@ svg {
   opacity: 0.5;
 }
 
-.media-scroller:has(.media-group:target)
-  .navigation-indicators
-  > *:nth-child(1) {
-  opacity: 0.5;
-}
-
-.navigation-indicators > *:nth-child(1),
-.media-group:nth-child(1):target ~ .navigation-indicators > *:nth-child(1) {
+.media-group:nth-child(1):hover ~ .navigation-indicators > *:nth-child(1) {
   opacity: 1;
 }
 
@@ -184,6 +171,6 @@ svg {
   opacity: 1;
 }
 
-.media-scroller:hover .navigation-indicators {
+.media-group:hover ~ .navigation-indicators {
   opacity: 1;
 }


### PR DESCRIPTION
I removed the necessity for the :has() selector in the CSS by not depending on the :target selector, but rather on :hover to display the right "buttons" and navigation indicators.